### PR TITLE
Add QR code tip to help content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frc-season-plan-builder",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.6.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react'
 import Header from './Header'
 
-const APP_VERSION = '1.6.0'
+const APP_VERSION = '1.6.1'
 
 interface LayoutProps {
   children: ReactNode

--- a/src/content/helpContent.tsx
+++ b/src/content/helpContent.tsx
@@ -46,6 +46,9 @@ export const overviewHelp: HelpSection = {
         <p className="text-gray-600 dark:text-gray-300">
           Choose something unique that others won't guess—combining your team number with a memorable phrase works well (e.g., "1234-turbo-bots"). Anyone with your code can view and edit your session.
         </p>
+        <p className="text-gray-600 dark:text-gray-300 mt-2">
+          <strong>Tip:</strong> Once in a session, click the QR code icon in the header to display a scannable code—perfect for quickly getting teammates connected on their phones.
+        </p>
       </section>
 
       <section>


### PR DESCRIPTION
## Summary

Adds a subtle note in the overview help pointing users to the QR code icon in the header for easy session sharing.

## Changes

- Added tip to "Session codes" section in overview help
- Bumped version to 1.6.1

## Screenshot location

The tip appears in: Help button (?) on HomePage → "Session codes" section

## Test plan

- [x] Open the app and click the help button (?)
- [x] Verify "Session codes" section has the new QR code tip

🤖 Generated with [Claude Code](https://claude.com/claude-code)