### PR TITLE
fix: show all pre-defined topics even when empty

### DIFF
--- a/src/components/retro/RetroTopicView.tsx
+++ b/src/components/retro/RetroTopicView.tsx
@@ -298,9 +298,6 @@ export default function RetroTopicView({
 
         {/* Topic sections */}
         {sections.map((section) => {
-          const hasAnyItems = section.columns.some((c) => c.items.length > 0)
-          if (!hasAnyItems) return null
-
           return (
             <div
               key={section.tag || '__untagged__'}


### PR DESCRIPTION
Topic sections with zero items were hidden by a hasAnyItems guard. Now all pre-defined tags always render as rows so they serve as visible droppable targets for DnD and match the user's pre-staged tag list.