### PR TITLE
Switch from custom domain to GitHub Pages project site

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-frcplanning.getwarped.net

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,0 @@
-frcplanning.getwarped.net

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,6 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
-  // Base path - use '/' for custom domains, '/repo-name/' for project sites
-  base: '/',
+  // Base path - project site under mattvevang.github.io
+  base: '/frcseasonplanbuilder.github.io/',
 })


### PR DESCRIPTION
## Summary
Removes the custom domain configuration and updates the Vite base path so the site is served directly from mattvevang.github.io/frcseasonplanbuilder.github.io/.

## Changes
- Remove CNAME files to prevent GitHub Pages from re-adding the custom domain on deploy
- Update Vite base path from / to /frcseasonplanbuilder.github.io/ so assets and routes resolve correctly

## Why
The custom domain frcplanning.getwarped.net is blocked by school network firewalls (Fortinet) as a Newly Observed Domain. Serving from github.io avoids this since it is a well-known whitelisted domain. A Cloudflare redirect rule will be set up separately.