### PR TITLE
fix: include base path in QR code session URLs

### DIFF
--- a/src/components/ui/QRCodeModal.tsx
+++ b/src/components/ui/QRCodeModal.tsx
@@ -9,10 +9,11 @@ interface QRCodeModalProps {
 }
 
 export default function QRCodeModal({ isOpen, onClose, sessionCode, pin }: QRCodeModalProps) {
-  // Include PIN in URL if available - allows teammates to join directly
+  // Build full URL using the configured base path (e.g. /frcseasonplanbuilder.github.io/)
+  const base = import.meta.env.BASE_URL.replace(/\/$/, '')
   const sessionUrl = pin
-    ? `${window.location.origin}/session/${sessionCode}?pin=${pin}`
-    : `${window.location.origin}/session/${sessionCode}`
+    ? `${window.location.origin}${base}/session/${sessionCode}?pin=${pin}`
+    : `${window.location.origin}${base}/session/${sessionCode}`
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} title="Share Session" size="sm">


### PR DESCRIPTION
## Problem
After switching from a custom domain to the GitHub Pages project site URL (\mattvevang.github.io/frcseasonplanbuilder.github.io/\), QR codes generated for session sharing pointed to the wrong URL.

The QR code used \window.location.origin\ which resolves to just \https://mattvevang.github.io\, missing the \/frcseasonplanbuilder.github.io/\ base path. Scanning the QR code would land on a different site instead of the session.

## Fix
Use \import.meta.env.BASE_URL\ (sourced from Vite's \ase\ config) to include the correct base path when building the session URL for the QR code.