### PR TITLE
fix: correct SPA redirect base path in 404.html

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -2,16 +2,16 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="/frcseasonplanbuilder.github.io/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>FRC Season Plan Builder</title>
     <script>
       // Single Page App redirect for GitHub Pages
       // Stores the path in sessionStorage and redirects to index.html
       // The SPA then reads this and navigates to the correct route
-      const path = window.location.pathname + window.location.search + window.location.hash;
+      var path = window.location.pathname + window.location.search + window.location.hash;
       sessionStorage.setItem('spa-redirect', path);
-      window.location.replace('/');
+      window.location.replace('/frcseasonplanbuilder.github.io/');
     </script>
   </head>
   <body>


### PR DESCRIPTION
## Problem
After switching from a custom domain to the GitHub Pages project site URL, refreshing the page on any deep route (e.g. \/frcseasonplanbuilder.github.io/session/demo-5555?pin=5555\) would bounce users to \https://mattvevang.github.io/\ instead of reloading the correct page.

GitHub Pages serves \404.html\ for unknown paths (which is all SPA routes). The 404.html script was redirecting to \/\ (the domain root) instead of \/frcseasonplanbuilder.github.io/\ where the actual app lives.

## Fix
- Updated \window.location.replace('/')\ → \window.location.replace('/frcseasonplanbuilder.github.io/')\ in 404.html
- Fixed the favicon href to also use the correct base path